### PR TITLE
Replace webpage_elements with locator column

### DIFF
--- a/database/setup.sql
+++ b/database/setup.sql
@@ -9,21 +9,10 @@ CREATE TABLE IF NOT EXISTS webpages (
 CREATE TABLE IF NOT EXISTS scrapes (
     scrape_id INT AUTO_INCREMENT PRIMARY KEY,
     webpage_id INT NOT NULL,
-    target_element_id INT NOT NULL,
+    locator VARCHAR(512) NOT NULL,
     metric_name VARCHAR(128),
     FOREIGN KEY (webpage_id) REFERENCES webpages(webpage_id) ON DELETE CASCADE,
-    FOREIGN KEY (target_element_id) REFERENCES webpage_elements(element_id),
-    UNIQUE (webpage_id, target_element_id)
-);
-
--- Represents DOM elements and their hierarchy
-CREATE TABLE IF NOT EXISTS webpage_elements (
-    element_id INT AUTO_INCREMENT PRIMARY KEY,
-    parent_element_id INT NULL,
-    dom_class VARCHAR(256),
-    dom_id VARCHAR(256),
-    dom_element VARCHAR(32),
-    FOREIGN KEY (parent_element_id) REFERENCES webpage_elements(element_id) ON DELETE CASCADE
+    UNIQUE(webpage_id, locator)
 );
 
 -- Stores scraped data values over time


### PR DESCRIPTION
Instead of seperating the parent elements and their details for storage and combining them again, just store the locator string in a simple column. The new table layout is shown below.

<img width="1297" height="327" alt="image" src="https://github.com/user-attachments/assets/f65ba8b4-b746-47a6-a2c4-b63105a6519f" />
